### PR TITLE
Bugfix: Set max height for payment icons

### DIFF
--- a/src/Plugin/Hyva/Checkout/Model/MethodMetaData/IconRenderer/RenderExternalIcon.php
+++ b/src/Plugin/Hyva/Checkout/Model/MethodMetaData/IconRenderer/RenderExternalIcon.php
@@ -22,6 +22,6 @@ class RenderExternalIcon
             return $result;
         }
 
-        return '<img class="h-11 w-11" src="' . $url . '" alt="Rvvup Payment Method" />';
+        return '<img class="max-h-11 w-11" src="' . $url . '" alt="Rvvup Payment Method" />';
     }
 }


### PR DESCRIPTION
Before:
<img width="63" alt="image" src="https://github.com/rvvup/magento-hyva-checkout/assets/5858697/9777bdf4-3d9e-4c89-ab6a-dfb1707d3fdc">

After:
<img width="84" alt="image" src="https://github.com/rvvup/magento-hyva-checkout/assets/5858697/a94dfbca-d96d-4707-aa42-c4a0e73a5766">
