### PR TITLE
Fixing issue with placing an offline payment after selecting rvvup methods

### DIFF
--- a/src/view/frontend/templates/component/payment/apple-pay-processor.phtml
+++ b/src/view/frontend/templates/component/payment/apple-pay-processor.phtml
@@ -18,12 +18,7 @@ use Magento\Framework\Escaper;
             const component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
             hyvaCheckout.payment.activate('rvvup_APPLE_PAY', {
                 placeOrderViaJs() {
-                    return true;
-                },
-
-                isVisibleInStep() {
-                    return hyvaCheckout.main.getElement().contains(this.el)
-                        && document.querySelector('[wire\\:key="rvvup_APPLE_PAY"].active')
+                    return document.querySelector('[wire\\:key="rvvup_APPLE_PAY"].active') !== null;
                 },
 
                 placeOrder() {

--- a/src/view/frontend/templates/component/payment/apple-pay-processor.phtml
+++ b/src/view/frontend/templates/component/payment/apple-pay-processor.phtml
@@ -21,6 +21,11 @@ use Magento\Framework\Escaper;
                     return true;
                 },
 
+                isVisibleInStep() {
+                    return hyvaCheckout.main.getElement().contains(this.el)
+                        && document.querySelector('[wire\\:key="rvvup_APPLE_PAY"].active')
+                },
+
                 placeOrder() {
                     return component.placeOrder();
                 }

--- a/src/view/frontend/templates/component/payment/card-inline-processor.phtml
+++ b/src/view/frontend/templates/component/payment/card-inline-processor.phtml
@@ -100,6 +100,11 @@ use Magento\Framework\Escaper;
                         return true;
                     },
 
+                    isVisibleInStep() {
+                        return hyvaCheckout.main.getElement().contains(this.el)
+                            && document.querySelector('[wire\\:key="rvvup_CARD"].active')
+                    },
+
                     placeOrder() {
                         return component.placeOrder();
                     }

--- a/src/view/frontend/templates/component/payment/card-inline-processor.phtml
+++ b/src/view/frontend/templates/component/payment/card-inline-processor.phtml
@@ -97,12 +97,7 @@ use Magento\Framework\Escaper;
                     },
 
                     placeOrderViaJs() {
-                        return true;
-                    },
-
-                    isVisibleInStep() {
-                        return hyvaCheckout.main.getElement().contains(this.el)
-                            && document.querySelector('[wire\\:key="rvvup_CARD"].active')
+                        return document.querySelector('[wire\\:key="rvvup_CARD"].active') !== null;
                     },
 
                     placeOrder() {

--- a/src/view/frontend/templates/component/payment/card-modal-processor.phtml
+++ b/src/view/frontend/templates/component/payment/card-modal-processor.phtml
@@ -19,12 +19,7 @@ use Magento\Framework\Escaper;
                 const component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
                 hyvaCheckout.payment.activate('rvvup_CARD', {
                     placeOrderViaJs() {
-                        return true;
-                    },
-
-                    isVisibleInStep() {
-                        return hyvaCheckout.main.getElement().contains(this.el)
-                            && document.querySelector('[wire\\:key="rvvup_CARD"].active')
+                        return document.querySelector('[wire\\:key="rvvup_CARD"].active') !== null;
                     },
 
                     placeOrder() {

--- a/src/view/frontend/templates/component/payment/card-modal-processor.phtml
+++ b/src/view/frontend/templates/component/payment/card-modal-processor.phtml
@@ -22,6 +22,11 @@ use Magento\Framework\Escaper;
                         return true;
                     },
 
+                    isVisibleInStep() {
+                        return hyvaCheckout.main.getElement().contains(this.el)
+                            && document.querySelector('[wire\\:key="rvvup_CARD"].active')
+                    },
+
                     placeOrder() {
                         return component.placeOrder();
                     }

--- a/src/view/frontend/templates/component/payment/clearpay-processor.phtml
+++ b/src/view/frontend/templates/component/payment/clearpay-processor.phtml
@@ -20,12 +20,7 @@ use Magento\Framework\Escaper;
             hyvaCheckout.payment.activate('rvvup_CLEARPAY', {
 
                 placeOrderViaJs() {
-                    return true;
-                },
-
-                isVisibleInStep() {
-                    return hyvaCheckout.main.getElement().contains(this.el)
-                        && document.querySelector('[wire\\:key="rvvup_CLEARPAY"].active')
+                    return document.querySelector('[wire\\:key="rvvup_CLEARPAY"].active') !== null;
                 },
 
                 placeOrder() {

--- a/src/view/frontend/templates/component/payment/clearpay-processor.phtml
+++ b/src/view/frontend/templates/component/payment/clearpay-processor.phtml
@@ -23,6 +23,11 @@ use Magento\Framework\Escaper;
                     return true;
                 },
 
+                isVisibleInStep() {
+                    return hyvaCheckout.main.getElement().contains(this.el)
+                        && document.querySelector('[wire\\:key="rvvup_CLEARPAY"].active')
+                },
+
                 placeOrder() {
                     return component.placeOrder();
                 }

--- a/src/view/frontend/templates/component/payment/crypto-processor.phtml
+++ b/src/view/frontend/templates/component/payment/crypto-processor.phtml
@@ -21,6 +21,11 @@ use Magento\Framework\Escaper;
                     return true;
                 },
 
+                isVisibleInStep() {
+                    return hyvaCheckout.main.getElement().contains(this.el)
+                        && document.querySelector('[wire\\:key="rvvup_CRYPTO"].active')
+                },
+
                 placeOrder() {
                     return component.placeOrder();
                 }

--- a/src/view/frontend/templates/component/payment/crypto-processor.phtml
+++ b/src/view/frontend/templates/component/payment/crypto-processor.phtml
@@ -18,12 +18,7 @@ use Magento\Framework\Escaper;
             const component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
             hyvaCheckout.payment.activate('rvvup_CRYPTO', {
                 placeOrderViaJs() {
-                    return true;
-                },
-
-                isVisibleInStep() {
-                    return hyvaCheckout.main.getElement().contains(this.el)
-                        && document.querySelector('[wire\\:key="rvvup_CRYPTO"].active')
+                    return document.querySelector('[wire\\:key="rvvup_CRYPTO"].active') !== null;
                 },
 
                 placeOrder() {

--- a/src/view/frontend/templates/component/payment/fake-processor.phtml
+++ b/src/view/frontend/templates/component/payment/fake-processor.phtml
@@ -21,6 +21,11 @@ use Magento\Framework\Escaper;
                     return true;
                 },
 
+                isVisibleInStep() {
+                    return hyvaCheckout.main.getElement().contains(this.el)
+                        && document.querySelector('[wire\\:key="rvvup_FAKE_PAYMENT_METHOD"].active')
+                },
+
                 placeOrder() {
                     return component.placeOrder();
                 }

--- a/src/view/frontend/templates/component/payment/fake-processor.phtml
+++ b/src/view/frontend/templates/component/payment/fake-processor.phtml
@@ -18,12 +18,7 @@ use Magento\Framework\Escaper;
             const component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
             hyvaCheckout.payment.activate('rvvup_FAKE_PAYMENT_METHOD', {
                 placeOrderViaJs() {
-                    return true;
-                },
-
-                isVisibleInStep() {
-                    return hyvaCheckout.main.getElement().contains(this.el)
-                        && document.querySelector('[wire\\:key="rvvup_FAKE_PAYMENT_METHOD"].active')
+                    return document.querySelector('[wire\\:key="rvvup_FAKE_PAYMENT_METHOD"].active') !== null;
                 },
 
                 placeOrder() {

--- a/src/view/frontend/templates/component/payment/paypal-processor.phtml
+++ b/src/view/frontend/templates/component/payment/paypal-processor.phtml
@@ -112,6 +112,11 @@
                     return true;
                 },
 
+                isVisibleInStep() {
+                    return hyvaCheckout.main.getElement().contains(this.el)
+                        && document.querySelector('[wire\\:key="rvvup_PAYPAL"].active')
+                },
+
                 placeOrder() {
                     return component.placeOrder();
                 },

--- a/src/view/frontend/templates/component/payment/paypal-processor.phtml
+++ b/src/view/frontend/templates/component/payment/paypal-processor.phtml
@@ -109,12 +109,7 @@
                 },
 
                 placeOrderViaJs() {
-                    return true;
-                },
-
-                isVisibleInStep() {
-                    return hyvaCheckout.main.getElement().contains(this.el)
-                        && document.querySelector('[wire\\:key="rvvup_PAYPAL"].active')
+                    return document.querySelector('[wire\\:key="rvvup_PAYPAL"].active') !== null;
                 },
 
                 placeOrder() {

--- a/src/view/frontend/templates/component/payment/yapily-processor.phtml
+++ b/src/view/frontend/templates/component/payment/yapily-processor.phtml
@@ -19,11 +19,7 @@ use Magento\Framework\Escaper;
             const component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
             hyvaCheckout.payment.activate('rvvup_YAPILY', {
                 placeOrderViaJs() {
-                    return true;
-                },
-                isVisibleInStep() {
-                    return hyvaCheckout.main.getElement().contains(this.el)
-                        && document.querySelector('[wire\\:key="rvvup_YAPILY"].active')
+                    return document.querySelector('[wire\\:key="rvvup_YAPILY"].active') !== null;
                 },
 
                 placeOrder() {

--- a/src/view/frontend/templates/component/payment/yapily-processor.phtml
+++ b/src/view/frontend/templates/component/payment/yapily-processor.phtml
@@ -21,6 +21,10 @@ use Magento\Framework\Escaper;
                 placeOrderViaJs() {
                     return true;
                 },
+                isVisibleInStep() {
+                    return hyvaCheckout.main.getElement().contains(this.el)
+                        && document.querySelector('[wire\\:key="rvvup_YAPILY"].active')
+                },
 
                 placeOrder() {
                     return component.placeOrder();


### PR DESCRIPTION
An open bug in Hyva causes this: https://gitlab.hyva.io/hyva-checkout/checkout/-/issues/204, this PR adds additional check to ensure the rvvup method is active before placing the order using the Rvvup processors to get around the issue until fixed in the core hyva checkout.