### PR TITLE
Handle error on load payment actions failure

### DIFF
--- a/src/Magewire/Checkout/Payment/AbstractProcessor.php
+++ b/src/Magewire/Checkout/Payment/AbstractProcessor.php
@@ -110,15 +110,25 @@ abstract class AbstractProcessor extends Component
 
     public function placeOrder(): void
     {
-        $this->loadPaymentActions();
-        $redirectUrl = $this->getRedirectUrl();
+        try {
+            $this->loadPaymentActions();
+            $redirectUrl = $this->getRedirectUrl();
 
-        $this->dispatchBrowserEvent(
-            'rvvup:update:showModal',
-            [
-                'redirectUrl' => $redirectUrl,
-            ]
-        );
+            $this->dispatchBrowserEvent(
+                'rvvup:update:showModal',
+                [
+                    'redirectUrl' => $redirectUrl,
+                ]
+            );
+        } catch (\Exception $exception) {
+            $detail = [
+                'text' => $exception->getMessage(),
+                'method' => $this->getMethodCode(),
+            ];
+
+            $this->dispatchBrowserEvent('order:place:error', $detail);
+            $this->dispatchBrowserEvent(sprintf('order:place:%s:error', $detail['method']), $detail);
+        }
     }
 
     /**

--- a/src/Magewire/Checkout/Payment/AbstractProcessor.php
+++ b/src/Magewire/Checkout/Payment/AbstractProcessor.php
@@ -128,6 +128,7 @@ abstract class AbstractProcessor extends Component
 
             $this->dispatchBrowserEvent('order:place:error', $detail);
             $this->dispatchBrowserEvent(sprintf('order:place:%s:error', $detail['method']), $detail);
+            $this->dispatchErrorMessage($detail['text']);
         }
     }
 


### PR DESCRIPTION
Dispatch error messages instead of generic error handling when payment method processors error

![image](https://github.com/user-attachments/assets/6708d311-b781-4b81-9bb3-71782548ab10)
