### PR TITLE
Workaround for Issue with Hyva Checkout post 1.3.0

### DIFF
--- a/src/view/frontend/templates/component/payment/apple-pay-hosted-processor.phtml
+++ b/src/view/frontend/templates/component/payment/apple-pay-hosted-processor.phtml
@@ -16,12 +16,25 @@ use Magento\Framework\View\Element\Template;
     </style>
     <script>
         (() => {
-            window.addEventListener('checkout:payment:method-activate', event => {
+            window.addEventListener('checkout:payment:method-activate', async event => {
                 if (event.detail.method !== 'rvvup_APPLE_PAY') {
                     return;
                 }
 
-                const component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+                /*
+                This code finds the magewire component, but the workaround is required because the component may not be
+                immediately available when the script is executed. This is related to an issue in Hyva Checkout 1.3.0 or
+                later. This is currently the suggested workaround provided by Hyva:
+                https://gitlab.hyva.io/hyva-checkout/checkout/-/issues/418
+                 */
+                let component;
+                try {
+                    component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+                } catch (error) {
+                    await Livewire.onLoad(() => {
+                        component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+                    });
+                }
                 hyvaCheckout.payment.activate('rvvup_APPLE_PAY', {
                     placeOrderViaJs() {
                         return document.querySelector('[wire\\:key="rvvup_APPLE_PAY"].active') !== null;

--- a/src/view/frontend/templates/component/payment/apple-pay-inline-processor.phtml
+++ b/src/view/frontend/templates/component/payment/apple-pay-inline-processor.phtml
@@ -97,7 +97,7 @@ use Magento\Framework\View\Element\Template;
                 }
             });
 
-            window.addEventListener('checkout:payment:method-activate', event => {
+            window.addEventListener('checkout:payment:method-activate', async event => {
                 let placeOrderButton = getPlaceOrderButton();
                 const divId = "rvvup-apple-pay-button";
 
@@ -112,7 +112,20 @@ use Magento\Framework\View\Element\Template;
 
                 $applePaySelected = true;
 
-                const component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+                /*
+                This code finds the magewire component, but the workaround is required because the component may not be
+                immediately available when the script is executed. This is related to an issue in Hyva Checkout 1.3.0 or
+                later. This is currently the suggested workaround provided by Hyva:
+                https://gitlab.hyva.io/hyva-checkout/checkout/-/issues/418
+                 */
+                let component;
+                try {
+                    component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+                } catch (error) {
+                    await Livewire.onLoad(() => {
+                        component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+                    });
+                }
                 hyvaCheckout.payment.activate('rvvup_APPLE_PAY', {
                     initialize() {
                         placeOrderButton.classList.add('rvvup_APPLE_PAY_place_order_button');

--- a/src/view/frontend/templates/component/payment/card-inline-processor.phtml
+++ b/src/view/frontend/templates/component/payment/card-inline-processor.phtml
@@ -29,13 +29,25 @@ use Magento\Framework\View\Element\Template;
                 });
             });
 
-            window.addEventListener('checkout:payment:method-activate', event => {
+            window.addEventListener('checkout:payment:method-activate', async event => {
                 if (event.detail.method !== 'rvvup_CARD') {
                     return;
                 }
 
-                const component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
-
+                /*
+                This code finds the magewire component, but the workaround is required because the component may not be
+                immediately available when the script is executed. This is related to an issue in Hyva Checkout 1.3.0 or
+                later. This is currently the suggested workaround provided by Hyva:
+                https://gitlab.hyva.io/hyva-checkout/checkout/-/issues/418
+                 */
+                let component;
+                try {
+                    component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+                } catch (error) {
+                    await Livewire.onLoad(() => {
+                        component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+                    });
+                }
                 hyvaCheckout.payment.activate('rvvup_CARD', {
                     initialize() {
                         ST = SecureTrading({

--- a/src/view/frontend/templates/component/payment/card-modal-processor.phtml
+++ b/src/view/frontend/templates/component/payment/card-modal-processor.phtml
@@ -12,12 +12,25 @@ use Magento\Framework\Escaper;
 <div wire:ignore>
     <script>
         (() => {
-            window.addEventListener('checkout:payment:method-activate', event => {
+            window.addEventListener('checkout:payment:method-activate', async event => {
                 if (event.detail.method !== 'rvvup_CARD') {
                     return;
                 }
 
-                const component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+                /*
+                This code finds the magewire component, but the workaround is required because the component may not be
+                immediately available when the script is executed. This is related to an issue in Hyva Checkout 1.3.0 or
+                later. This is currently the suggested workaround provided by Hyva:
+                https://gitlab.hyva.io/hyva-checkout/checkout/-/issues/418
+                 */
+                let component;
+                try {
+                    component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+                } catch (error) {
+                    await Livewire.onLoad(() => {
+                        component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+                    });
+                }
                 hyvaCheckout.payment.activate('rvvup_CARD', {
                     placeOrderViaJs() {
                         return document.querySelector('[wire\\:key="rvvup_CARD"].active') !== null;

--- a/src/view/frontend/templates/component/payment/clearpay-processor.phtml
+++ b/src/view/frontend/templates/component/payment/clearpay-processor.phtml
@@ -1,8 +1,8 @@
 <?php
 declare(strict_types=1);
 
-use Magento\Framework\View\Element\Template;
 use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
 
 /** @var Template $block */
 /** @var Escaper $escaper */
@@ -12,12 +12,25 @@ use Magento\Framework\Escaper;
 <div wire:ignore>
 <script>
     (() => {
-        window.addEventListener('checkout:payment:method-activate', event => {
+        window.addEventListener('checkout:payment:method-activate', async event => {
             if (event.detail.method !== 'rvvup_CLEARPAY') {
                 return;
             }
 
-            const component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+            /*
+            This code finds the magewire component, but the workaround is required because the component may not be
+            immediately available when the script is executed. This is related to an issue in Hyva Checkout 1.3.0 or
+            later. This is currently the suggested workaround provided by Hyva:
+            https://gitlab.hyva.io/hyva-checkout/checkout/-/issues/418
+             */
+            let component;
+            try {
+                component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+            } catch (error) {
+                await Livewire.onLoad(() => {
+                    component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+                });
+            }
             hyvaCheckout.payment.activate('rvvup_CLEARPAY', {
 
                 placeOrderViaJs() {

--- a/src/view/frontend/templates/component/payment/crypto-processor.phtml
+++ b/src/view/frontend/templates/component/payment/crypto-processor.phtml
@@ -11,12 +11,25 @@ use Magento\Framework\Escaper;
 <div wire:ignore>
 <script>
     (() => {
-        window.addEventListener('checkout:payment:method-activate', event => {
+        window.addEventListener('checkout:payment:method-activate', async event => {
             if (event.detail.method !== 'rvvup_CRYPTO') {
                 return;
             }
 
-            const component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+            /*
+            This code finds the magewire component, but the workaround is required because the component may not be
+            immediately available when the script is executed. This is related to an issue in Hyva Checkout 1.3.0 or
+            later. This is currently the suggested workaround provided by Hyva:
+            https://gitlab.hyva.io/hyva-checkout/checkout/-/issues/418
+             */
+            let component;
+            try {
+                component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+            } catch (error) {
+                await Livewire.onLoad(() => {
+                    component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+                });
+            }
             hyvaCheckout.payment.activate('rvvup_CRYPTO', {
                 placeOrderViaJs() {
                     return document.querySelector('[wire\\:key="rvvup_CRYPTO"].active') !== null;

--- a/src/view/frontend/templates/component/payment/fake-processor.phtml
+++ b/src/view/frontend/templates/component/payment/fake-processor.phtml
@@ -11,12 +11,25 @@ use Magento\Framework\Escaper;
 <div wire:ignore>
 <script>
     (() => {
-        window.addEventListener('checkout:payment:method-activate', event => {
+        window.addEventListener('checkout:payment:method-activate', async event => {
             if (event.detail.method !== 'rvvup_FAKE_PAYMENT_METHOD') {
                 return;
             }
 
-            const component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+            /*
+            This code finds the magewire component, but the workaround is required because the component may not be
+            immediately available when the script is executed. This is related to an issue in Hyva Checkout 1.3.0 or
+            later. This is currently the suggested workaround provided by Hyva:
+            https://gitlab.hyva.io/hyva-checkout/checkout/-/issues/418
+             */
+            let component;
+            try {
+                component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+            } catch (error) {
+                await Livewire.onLoad(() => {
+                    component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+                });
+            }
             hyvaCheckout.payment.activate('rvvup_FAKE_PAYMENT_METHOD', {
                 placeOrderViaJs() {
                     return document.querySelector('[wire\\:key="rvvup_FAKE_PAYMENT_METHOD"].active') !== null;

--- a/src/view/frontend/templates/component/payment/google-pay-processor.phtml
+++ b/src/view/frontend/templates/component/payment/google-pay-processor.phtml
@@ -12,12 +12,25 @@ use Magento\Framework\Escaper;
 <div wire:ignore>
 <script>
     (() => {
-        window.addEventListener('checkout:payment:method-activate', event => {
+        window.addEventListener('checkout:payment:method-activate', async event => {
             if (event.detail.method !== 'rvvup_GOOGLE_PAY') {
                 return;
             }
 
-            const component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+            /*
+            This code finds the magewire component, but the workaround is required because the component may not be
+            immediately available when the script is executed. This is related to an issue in Hyva Checkout 1.3.0 or
+            later. This is currently the suggested workaround provided by Hyva:
+            https://gitlab.hyva.io/hyva-checkout/checkout/-/issues/418
+             */
+            let component;
+            try {
+                component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+            } catch (error) {
+                await Livewire.onLoad(() => {
+                    component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+                });
+            }
             hyvaCheckout.payment.activate('rvvup_GOOGLE_PAY', {
                 placeOrderViaJs() {
                     return document.querySelector('[wire\\:key="rvvup_GOOGLE_PAY"].active') !== null;

--- a/src/view/frontend/templates/component/payment/klarna-processor.phtml
+++ b/src/view/frontend/templates/component/payment/klarna-processor.phtml
@@ -12,12 +12,25 @@ use Magento\Framework\Escaper;
 <div wire:ignore>
 <script>
     (() => {
-        window.addEventListener('checkout:payment:method-activate', event => {
+        window.addEventListener('checkout:payment:method-activate', async event => {
             if (event.detail.method !== 'rvvup_KLARNA') {
                 return;
             }
 
-            const component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+            /*
+            This code finds the magewire component, but the workaround is required because the component may not be
+            immediately available when the script is executed. This is related to an issue in Hyva Checkout 1.3.0 or
+            later. This is currently the suggested workaround provided by Hyva:
+            https://gitlab.hyva.io/hyva-checkout/checkout/-/issues/418
+             */
+            let component;
+            try {
+                component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+            } catch (error) {
+                await Livewire.onLoad(() => {
+                    component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+                });
+            }
             hyvaCheckout.payment.activate('rvvup_KLARNA', {
                 placeOrderViaJs() {
                     return document.querySelector('[wire\\:key="rvvup_KLARNA"].active') !== null;

--- a/src/view/frontend/templates/component/payment/yapily-processor.phtml
+++ b/src/view/frontend/templates/component/payment/yapily-processor.phtml
@@ -12,12 +12,25 @@ use Magento\Framework\Escaper;
 <div wire:ignore>
 <script>
     (() => {
-        window.addEventListener('checkout:payment:method-activate', event => {
+        window.addEventListener('checkout:payment:method-activate', async event => {
             if (event.detail.method !== 'rvvup_YAPILY') {
                 return;
             }
 
-            const component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+            /*
+            This code finds the magewire component, but the workaround is required because the component may not be
+            immediately available when the script is executed. This is related to an issue in Hyva Checkout 1.3.0 or
+            later. This is currently the suggested workaround provided by Hyva:
+            https://gitlab.hyva.io/hyva-checkout/checkout/-/issues/418
+             */
+            let component;
+            try {
+                component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+            } catch (error) {
+                await Livewire.onLoad(() => {
+                    component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+                });
+            }
             hyvaCheckout.payment.activate('rvvup_YAPILY', {
                 placeOrderViaJs() {
                     return document.querySelector('[wire\\:key="rvvup_YAPILY"].active') !== null;


### PR DESCRIPTION
This code finds the magewire component, but the workaround is required because the component may not be
                immediately available when the script is executed. This is related to an issue in Hyva Checkout 1.3.0 or
                later. This is currently the suggested workaround provided by Hyva:
                https://gitlab.hyva.io/hyva-checkout/checkout/-/issues/418