### PR TITLE
[Launchpad Test] PAY-81: Apple Pay express checkout on PDP

### DIFF
--- a/src/Magewire/Checkout/Payment/RvvupExpressProcessor.php
+++ b/src/Magewire/Checkout/Payment/RvvupExpressProcessor.php
@@ -8,9 +8,15 @@ use Magento\Checkout\Model\Session;
 use Magento\Framework\Exception\AlreadyExistsException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\UrlInterface;
 use Magento\Quote\Model\Quote;
+use Magento\Store\Model\StoreManagerInterface;
 use Magewirephp\Magewire\Component;
+use Psr\Log\LoggerInterface;
+use Rvvup\Api\Model\ApplicationSource;
+use Rvvup\Api\Model\CheckoutCreateInput;
 use Rvvup\Api\Model\PaymentType;
+use Rvvup\Payments\Service\ApiProvider;
 use Rvvup\Payments\Service\Express\ExpressPaymentManager;
 use Rvvup\Payments\Service\Express\ExpressPaymentRequestMapper;
 use Rvvup\Payments\Service\Shipping\ShippingMethodService;
@@ -37,7 +43,6 @@ class RvvupExpressProcessor extends Component
     /** @var ExpressPaymentManager */
     private $expressPaymentManager;
 
-
     /** @var ShippingMethodService */
     private $shippingMethodService;
 
@@ -47,8 +52,20 @@ class RvvupExpressProcessor extends Component
     /** @var ExpressPaymentRequestMapper */
     private $expressPaymentRequestMapper;
 
+    /** @var ApiProvider */
+    private $apiProvider;
+
+    /** @var StoreManagerInterface */
+    private $storeManager;
+
+    /** @var LoggerInterface */
+    private $logger;
+
     /** @var array */
     public $paymentSessionResult;
+
+    /** @var string|null Token returned when checkout is created on demand (PDP flow) */
+    public $checkoutToken = null;
 
     /** @var array */
     public $shippingAddressChangeResult = [];
@@ -62,20 +79,28 @@ class RvvupExpressProcessor extends Component
      * @param ExpressPaymentManager $expressPaymentManager
      * @param ShippingMethodService $shippingMethodService
      * @param ExpressPaymentRequestMapper $expressPaymentRequestMapper
+     * @param ApiProvider $apiProvider
+     * @param StoreManagerInterface $storeManager
+     * @param LoggerInterface $logger
      */
     public function __construct(
-        Session               $checkoutSession,
-        PaymentSessionManager $paymentSessionManager,
-        ExpressPaymentManager $expressPaymentManager,
+        Session                     $checkoutSession,
+        PaymentSessionManager       $paymentSessionManager,
+        ExpressPaymentManager       $expressPaymentManager,
         ShippingMethodService       $shippingMethodService,
-        ExpressPaymentRequestMapper $expressPaymentRequestMapper
-    )
-    {
+        ExpressPaymentRequestMapper $expressPaymentRequestMapper,
+        ApiProvider                 $apiProvider,
+        StoreManagerInterface       $storeManager,
+        LoggerInterface             $logger
+    ) {
         $this->paymentSessionManager = $paymentSessionManager;
         $this->checkoutSession = $checkoutSession;
         $this->expressPaymentManager = $expressPaymentManager;
         $this->shippingMethodService = $shippingMethodService;
         $this->expressPaymentRequestMapper = $expressPaymentRequestMapper;
+        $this->apiProvider = $apiProvider;
+        $this->storeManager = $storeManager;
+        $this->logger = $logger;
     }
 
     /**
@@ -151,11 +176,55 @@ class RvvupExpressProcessor extends Component
      * @throws AlreadyExistsException
      * @throws LocalizedException
      */
-    public function createPaymentSession(string $checkoutId, array $data): void
+    public function createPaymentSession(?string $checkoutId, array $data): void
     {
+        if (!$checkoutId) {
+            $checkout = $this->createCheckoutOnDemand();
+            $checkoutId = $checkout['id'];
+            $this->checkoutToken = $checkout['token'];
+        }
+
         $quote = $this->expressPaymentManager->updateQuoteBeforePaymentAuth($this->checkoutSession->getQuote(), $data);
         $this->setQuoteData($quote);
         $this->paymentSessionResult = $this->paymentSessionManager->create($quote, $checkoutId, $this, PaymentType::EXPRESS);
+    }
+
+    /**
+     * Create a Rvvup checkout on demand for PDP express checkout flow.
+     *
+     * @return array{id: string, token: string}
+     * @throws LocalizedException
+     */
+    private function createCheckoutOnDemand(): array
+    {
+        try {
+            $storeId = (string) $this->storeManager->getStore()->getId();
+            $checkoutInput = (new CheckoutCreateInput())->setSource(ApplicationSource::MAGENTO_CHECKOUT);
+
+            try {
+                $checkoutInput->setMetadata([
+                    "domain" => $this->storeManager->getStore()->getBaseUrl(UrlInterface::URL_TYPE_WEB, true)
+                ]);
+            } catch (\Exception $e) {
+                $this->logger->error('Ignoring error getting base url: ' . $e->getMessage());
+            }
+
+            $result = $this->apiProvider->getSdk($storeId)->checkouts()->create($checkoutInput, null);
+
+            if (!$result->getId() || !$result->getToken()) {
+                throw new LocalizedException(__('Failed to create Rvvup checkout'));
+            }
+
+            return [
+                'id' => $result->getId(),
+                'token' => $result->getToken(),
+            ];
+        } catch (LocalizedException $e) {
+            throw $e;
+        } catch (\Exception $e) {
+            $this->logger->error('Error creating on-demand checkout: ' . $e->getMessage());
+            throw new LocalizedException(__('Failed to create Rvvup checkout'));
+        }
     }
 
     /**

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -50,6 +50,13 @@
         </arguments>
     </type>
 
+    <type name="Rvvup\PaymentsHyvaCheckout\Magewire\Checkout\Payment\RvvupExpressProcessor">
+        <arguments>
+            <argument name="checkoutSession" xsi:type="object">Magento\Checkout\Model\Session\Proxy</argument>
+            <argument name="logger" xsi:type="object">Rvvup\Payments\Model\Logger</argument>
+        </arguments>
+    </type>
+
     <type name="Rvvup\PaymentsHyvaCheckout\Magewire\Product\View\Info\Addtocart">
         <arguments>
             <argument name="checkoutSession" xsi:type="object">Magento\Checkout\Model\Session\Proxy</argument>

--- a/src/view/frontend/layout/catalog_product_view.xml
+++ b/src/view/frontend/layout/catalog_product_view.xml
@@ -10,5 +10,17 @@
                 <argument name="magewire" xsi:type="object">Rvvup\PaymentsHyvaCheckout\Magewire\Product\View\Info\Addtocart</argument>
             </arguments>
         </referenceBlock>
+        <referenceContainer name="product.info.main">
+            <block name="rvvup.pdp.express-checkout"
+                   template="Rvvup_PaymentsHyvaCheckout::component/payment/rvvup-express.phtml"
+                   after="product.info.addtocart"
+                   ifconfig="payment/rvvup/active">
+                <arguments>
+                    <argument name="magewire" xsi:type="object">
+                        Rvvup\PaymentsHyvaCheckout\Magewire\Checkout\Payment\RvvupExpressProcessor
+                    </argument>
+                </arguments>
+            </block>
+        </referenceContainer>
     </body>
 </page>

--- a/src/view/frontend/templates/component/payment/rvvup-express.phtml
+++ b/src/view/frontend/templates/component/payment/rvvup-express.phtml
@@ -73,36 +73,43 @@ use Rvvup\PaymentsHyvaCheckout\Magewire\Checkout\Payment\RvvupExpressProcessor;
             margin-right: 20px;
         }
     </style>
-    <div x-data="rvvupExpressButtons"
+    <?php $blockId = $escaper->escapeHtmlAttr(str_replace('.', '-', $block->getNameInLayout())); ?>
+    <div x-data="rvvupExpressButtons_<?= $blockId ?>"
          x-init="initRvvup"
+         id="rvvup-express-container-<?= $blockId ?>"
          class="rvvup_express_container">
         <div class="rvvup_express_title rvvup_express_text_with_line">Express Checkout</div>
         <div class="rvvup_express_wrapper">
-            <div id="rvvup-express-element" class="rvvup_express_element"></div>
+            <div id="rvvup-express-element-<?= $blockId ?>" class="rvvup_express_element"></div>
         </div>
         <div class="rvvup_express_divider_text rvvup_express_text_with_line">OR</div>
     </div>
     <script>
-        function rvvupExpressButtons() {
+        function rvvupExpressButtons_<?= $blockId ?>() {
             return {
                 initRvvup() {
                     const component = Magewire.find('<?= $escaper->escapeJs($block->getNameInLayout()) ?>');
+                    const containerId = 'rvvup-express-container-<?= $blockId ?>';
+                    const elementSelector = '#rvvup-express-element-<?= $blockId ?>';
                     let enabledPaymentMethods = [];
                     const applePayExpressEnabled = rvvup_parameters?.settings?.apple_pay?.checkout?.express?.enabled || false;
-                    const rvvupCheckout = rvvup_parameters?.checkout;
+                    const rvvupCheckout = rvvup_parameters?.checkout || null;
                     if (applePayExpressEnabled) {
                         enabledPaymentMethods.push('APPLE_PAY');
                     }
-                    if (enabledPaymentMethods.length === 0 || !rvvupCheckout) {
+                    if (enabledPaymentMethods.length === 0) {
                         return;
                     }
-                    window.rvvup_sdk.createExpressCheckout({
-                        checkoutSessionKey: rvvupCheckout.token,
+                    const expressOptions = {
                         enabledPaymentMethods: enabledPaymentMethods,
-                    }).then(expressCheckout => {
+                    };
+                    if (rvvupCheckout?.token) {
+                        expressOptions.checkoutSessionKey = rvvupCheckout.token;
+                    }
+                    window.rvvup_sdk.createExpressCheckout(expressOptions).then(expressCheckout => {
                         expressCheckout.on("ready", (data) => {
                             if (data.paymentMethods.length > 0) {
-                                document.getElementsByClassName('rvvup_express_container')[0].classList.add('show')
+                                document.getElementById(containerId).classList.add('show')
                             }
                         });
 
@@ -126,9 +133,11 @@ use Rvvup\PaymentsHyvaCheckout\Magewire\Checkout\Payment\RvvupExpressProcessor;
                             };
                         });
                         expressCheckout.on("beforePaymentAuth", async (data) => {
-                            await component.createPaymentSession(rvvupCheckout.id, data)
+                            var checkoutId = rvvupCheckout?.id || null;
+                            await component.createPaymentSession(checkoutId, data);
                             return {
-                                paymentSessionId: component.paymentSessionResult.paymentSessionId
+                                checkoutSessionKey: component.checkoutToken || rvvupCheckout?.token,
+                                paymentSessionId: component.paymentSessionResult.paymentSessionId,
                             };
                         });
                         expressCheckout.on("paymentAuthorized", () => {
@@ -154,7 +163,7 @@ use Rvvup\PaymentsHyvaCheckout\Magewire\Checkout\Payment\RvvupExpressProcessor;
                             }
                         });
                         expressCheckout.mount({
-                            selector: "#rvvup-express-element",
+                            selector: elementSelector,
                         });
                     }).catch(e => {
                         console.error("Error creating express checkout", e);
@@ -162,7 +171,7 @@ use Rvvup\PaymentsHyvaCheckout\Magewire\Checkout\Payment\RvvupExpressProcessor;
                 },
             }
         }
-        window.addEventListener('alpine:init', () => Alpine.data('rvvupExpressButtons', rvvupExpressButtons), {once: true});
+        window.addEventListener('alpine:init', () => Alpine.data('rvvupExpressButtons_<?= $blockId ?>', rvvupExpressButtons_<?= $blockId ?>), {once: true});
     </script>
 <?php $hyvaCsp->registerInlineScript() ?>
 


### PR DESCRIPTION
## Summary

Adapts the existing Hyva express checkout for Apple Pay on product pages (PDP) using the deferred `checkoutSessionKey` pattern.

### Changes
- **`Magewire/Checkout/Payment/RvvupExpressProcessor.php`**: Creates Rvvup checkout on demand when `checkoutId` is null (PDP flow). New `$checkoutToken` public property for Magewire access.
- **`view/frontend/templates/component/payment/rvvup-express.phtml`**: Handles missing `rvvup_parameters.checkout` gracefully. Returns `checkoutSessionKey` from on-demand creation.
- **`view/frontend/layout/catalog_product_view.xml`** (new): Mounts express checkout on PDP
- **`etc/di.xml`**: DI config for `RvvupExpressProcessor` dependencies

### Flow
1. Product page loads -> SDK init with `publishableKey` only (no checkout created)
2. Apple Pay button renders via existing `createExpressCheckout()`
3. User clicks -> `beforePaymentAuth` -> Magewire creates checkout on demand via PHP SDK
4. Payment session created with new checkout ID
5. Returns `{ checkoutSessionKey, paymentSessionId }` to SDK
6. Apple Pay sheet opens -> payment completes -> redirect

Generated with [Claude Code](https://claude.com/claude-code) via pos-launchpad