### PR TITLE
Prevent double initialization of the card payment method

### DIFF
--- a/src/view/frontend/templates/component/payment/card-inline-processor.phtml
+++ b/src/view/frontend/templates/component/payment/card-inline-processor.phtml
@@ -50,6 +50,9 @@ use Magento\Framework\View\Element\Template;
                 }
                 hyvaCheckout.payment.activate('rvvup_CARD', {
                     initialize() {
+                        if (ST !== null) {
+                            return;
+                        }
                         ST = SecureTrading({
                             jwt: '<?= $magewire->getInitializationToken() ?>',
                             animatedCard: true,


### PR DESCRIPTION
Add guard in initialize function of the card payment method to prevent double initialization from Trust Payments