### PR TITLE
Include latest Hyvä checkout in e2e matrix

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -20,6 +20,10 @@ jobs:
           - MAGENTO_VERSION: 2.4.7
             HYVA_CHECKOUT_VERSION: 1.3.10
           - MAGENTO_VERSION: 2.4.7
+            HYVA_CHECKOUT_VERSION: 1.3.11
+          - MAGENTO_VERSION: 2.4.7
+            HYVA_CHECKOUT_VERSION: 1.3.12
+          - MAGENTO_VERSION: 2.4.7
             HYVA_CHECKOUT_VERSION: latest
 
     env:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -19,6 +19,8 @@ jobs:
             HYVA_CHECKOUT_VERSION: 1.3.9
           - MAGENTO_VERSION: 2.4.7
             HYVA_CHECKOUT_VERSION: 1.3.10
+          - MAGENTO_VERSION: 2.4.7
+            HYVA_CHECKOUT_VERSION: latest
 
     env:
       MAGENTO_VERSION: ${{ matrix.MAGENTO_VERSION }}

--- a/scripts/helpers/wait-for-server-startup.sh
+++ b/scripts/helpers/wait-for-server-startup.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 URL="${1:-http://local.dev.rvvuptech.com:89/magento_version}"
-TIMEOUT="${2:-500}"
+TIMEOUT="${2:-1000}"
 
 start=$(date +%s)
 attempt=1

--- a/scripts/helpers/wait-for-server-startup.sh
+++ b/scripts/helpers/wait-for-server-startup.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 URL="${1:-http://local.dev.rvvuptech.com:89/magento_version}"
-TIMEOUT="${2:-1000}"
+TIMEOUT="${2:-2000}"
 
 start=$(date +%s)
 attempt=1


### PR DESCRIPTION
Include an e2e run against the latest Hyvä checkout version